### PR TITLE
fix: file content decode error

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,20 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "a36a5392bb1e8bbc06bfaa0761e52593cf2d83b486696bf54667ba8da616c839"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {}
+}

--- a/src/airlogger/fastapi.py
+++ b/src/airlogger/fastapi.py
@@ -15,7 +15,7 @@ try:
     # imports requests for forcing original module's register
     import requests
 
-    # import airlogger.requests as airlogger_requests 
+    # import airlogger.requests as airlogger_requests
     from airlogger import requests as airlogger_requests
 
     # removes original module's register
@@ -30,12 +30,14 @@ except ImportError:
 def init_app(app, require_trace_id: bool = True):
     from fastapi import Request
     from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.datastructures import UploadFile
     from fastapi.responses import JSONResponse
 
     globals.airlogger = logging.getLogger('airlogger')
     globals.airlogger.propagate = True
     globals.airlogger.setLevel(logging.INFO)
-    globals.airlogger.addHandler(AirTraceHandler(app.title, 'webserver', require_trace_id))
+    globals.airlogger.addHandler(AirTraceHandler(
+        app.title, 'webserver', require_trace_id))
 
     async def receive_body(request: Request):
 
@@ -50,21 +52,35 @@ def init_app(app, require_trace_id: bool = True):
 
     async def func(request: Request, call_next):
 
-        globals.air_trace_id = request.headers.get('X-Air-Trace-Id', str(uuid4()))
+        globals.air_trace_id = request.headers.get(
+            'X-Air-Trace-Id', str(uuid4()))
         start_time = time.time()
 
         await receive_body(request)
         body_content = {}
 
-        try:
-            body = await request.body()
-            body = body.decode()
-            body_content = json.loads(body)
-        except ValueError:
-            pass
-        except UnicodeDecodeError:
-            pass
+        form_data = await request.form()
+        files = []
 
+        for field in form_data:
+            form_field = form_data[field]
+            if isinstance(form_field, UploadFile):
+                files.append(form_field)
+
+        if files:
+            body_content = {
+                'files': [f.filename for f in files]
+            }
+
+        else:
+            try:
+                body = await request.body()
+                body = body.decode()
+                body_content = json.loads(body)
+            except ValueError:
+                pass
+            except UnicodeDecodeError:
+                pass
 
         air_request_id = str(uuid4())
 
@@ -75,7 +91,6 @@ def init_app(app, require_trace_id: bool = True):
             'event_type': 'REQUEST',
             'body': body_content,
         }
-
 
         if isinstance(app.extra.get('AIR_HOOK_LOG_REQUEST'), FunctionType):
             hook_result = app.extra.get['AIR_HOOK_LOG_REQUEST'](request)

--- a/src/airlogger/fastapi.py
+++ b/src/airlogger/fastapi.py
@@ -54,13 +54,17 @@ def init_app(app, require_trace_id: bool = True):
         start_time = time.time()
 
         await receive_body(request)
-        body = await request.body()
-        body = body.decode()
+        body_content = {}
 
         try:
-            body = json.loads(body)
+            body = await request.body()
+            body = body.decode()
+            body_content = json.loads(body)
         except ValueError:
             pass
+        except UnicodeDecodeError:
+            pass
+
 
         air_request_id = str(uuid4())
 
@@ -69,8 +73,9 @@ def init_app(app, require_trace_id: bool = True):
             'endpoint': request.url.path,
             'request_id': air_request_id,
             'event_type': 'REQUEST',
-            'body': body,
+            'body': body_content,
         }
+
 
         if isinstance(app.extra.get('AIR_HOOK_LOG_REQUEST'), FunctionType):
             hook_result = app.extra.get['AIR_HOOK_LOG_REQUEST'](request)


### PR DESCRIPTION
When using file upload on fastapi's handler, the old body.decode() call raises UnicodeDecodeError.

At this level, the simpliest and direct solution is wrap the whole block with try/except