### PR TITLE
Feat/logging options

### DIFF
--- a/src/airlogger/celery.py
+++ b/src/airlogger/celery.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 import logging
 import sys
 from time import time

--- a/src/airlogger/utils/sanitizer.py
+++ b/src/airlogger/utils/sanitizer.py
@@ -1,0 +1,18 @@
+from typing import Any, Dict
+
+
+SANITIZED_FIELDS = [
+    "password",
+    "token",
+    "access_token",
+    "refresh_token",
+    "auth_code"
+]
+
+
+def sanitize_body(data: Dict[str, Any]):
+    for key in data:
+        if key in SANITIZED_FIELDS:
+            data[key] = "******"
+
+    return data


### PR DESCRIPTION
# Description
This update adds three new options to fastapi's logger init_app to keep a future standard in init_app:

```py
def init_app(
    app,
    require_trace_id: bool = True,
    logger_level: str = logging.INFO, # this
    log_request_body: str = True, # this
    log_response_body: str = True # this
):
```

# How it works

**logger_level:** is the default setLevel from airlogger
**log_request_body:** if this option is False, the body from request ("incoming request") will be suppressed
**log_response_body:** if this option is False, the body from response ("outcome request") will be suppressed


# Additional

A new package ```utils.sanitizer``` that uses a sanitize_body method to remove sensitive fields in logging body
The dafults are setted by SANITIZED_FIELDS const 
```py

SANITIZED_FIELDS = [
    "password",
    "token",
    "access_token",
    "refresh_token",
    "auth_code"
]
```

